### PR TITLE
Add custom type error message mapping

### DIFF
--- a/src/defaultErrorCodeMessageMappers.ts
+++ b/src/defaultErrorCodeMessageMappers.ts
@@ -1,0 +1,15 @@
+
+const REGEX_2792 = /([^\n]+) Did you mean to set the 'moduleResolution' option to 'node', or to add aliases to the 'paths' option\?/;
+
+export const defaultErrorCodeMessageMappers: {
+  [key: number]: (msg: string) => string | undefined;
+} = {
+  2792: msg => {
+    const match = REGEX_2792.exec(msg);
+    if (match !== null) {
+      return match[1];
+    }
+  },
+};
+
+

--- a/src/utils/errorMessageMapping.ts
+++ b/src/utils/errorMessageMapping.ts
@@ -1,0 +1,34 @@
+import type ts from "typescript";
+
+function callMapper(msg: string, code: number, errorCodeMessageMappers: {[errorCode: number]: (message: string) => string | undefined}): string {
+  const mesageMapper = errorCodeMessageMappers[code];
+  if (mesageMapper === undefined) {
+    return msg;
+  }
+  const mappedMessage = mesageMapper(msg);
+  if (mappedMessage === undefined) {
+    throw new Error(`Insufficient message mapper found for ts diagnostic code ${code}`);
+  }
+  return mappedMessage;
+}
+
+export function createMapDiagnosticMessage(errorCodeMessageMappers: {[errorCode: number]: (message: string) => string | undefined}) {
+  function mapDiagnosticMessageChain(msg: string | ts.DiagnosticMessageChain, code: number): string[] {
+    let errorMessages: string[] = [];
+    if (typeof msg === 'string') {
+      if (code === undefined) {
+        throw new Error('Must provide a code when mapping a string message');
+      }
+      errorMessages.push(callMapper(msg, code, errorCodeMessageMappers));
+    } else if (msg.next) {
+      for (const next of msg.next) {
+        errorMessages = errorMessages.concat(mapDiagnosticMessageChain(next, next.code));
+      }
+    }
+    return errorMessages;
+  }
+  function mapDiagnosticMessage(diagnostic:  ts.Diagnostic): string[] {
+    return mapDiagnosticMessageChain(diagnostic.messageText, diagnostic.code);
+  }
+  return mapDiagnosticMessage;
+}

--- a/test/UserCodeRunner.spec.ts
+++ b/test/UserCodeRunner.spec.ts
@@ -71,7 +71,7 @@ it('should produce return type errors', async () => {
 
   expect(result.isErr()).toBeTruthy();
   expect(result.unwrapErr()[0].message).toBe(`
-    TypeError: Incorrect return type. Expected: 'number', Actual: 'string'.
+    TypeError: TS2322 Incorrect return type. Expected: 'number', Actual: 'string'.
     `.trimTemplate());
   expect(result.unwrapErr()[0].stack).toBe(`
     at MyDSLFunction(0:54)
@@ -110,7 +110,7 @@ it('should produce input type errors', async () => {
 
   expect(result.isErr()).toBeTruthy();
   expect(result.unwrapErr()[0].message).toBe(`
-    TypeError: Incorrect argument type. Expected: '[string]', Actual: '[string, number]'.
+    TypeError: TS2554 Incorrect argument type. Expected: '[string]', Actual: '[string, number]'.
     `.trimTemplate());
   expect(result.unwrapErr()[0].stack).toBe(`
     at MyDSLFunction(0:38)
@@ -145,7 +145,7 @@ it('should produce internal type errors', async () => {
 
   expect(result.isErr()).toBeTruthy();
   expect(result.unwrapErr()[0].message).toBe(`
-    TypeError: Type 'string' is not assignable to type 'number'.
+    TypeError: TS2322 Type 'string' is not assignable to type 'number'.
     `.trimTemplate());
   expect(result.unwrapErr()[0].stack).toBe(`
     at MyDSLFunction(1:8)
@@ -300,7 +300,7 @@ test('Aerie undefined node test', async () => {
 
   expect(result.unwrapErr()).toMatchObject(expect.arrayContaining([
     expect.objectContaining({
-      message: "TypeError: Incorrect return type. Expected: 'Command[] | Command | null', Actual: 'ExpansionReturn'.",
+      message: "TypeError: TS2322 Incorrect return type. Expected: 'Command[] | Command | null', Actual: 'ExpansionReturn'.",
       stack: 'at BakeBananaBreadExpansionLogic(5:3)',
       sourceContext: ' 5|   context: Context\n' +
         '>6| ): ExpansionReturn {\n' +
@@ -309,7 +309,7 @@ test('Aerie undefined node test', async () => {
       location: { line: 5, column: 3 }
     }),
     expect.objectContaining({
-      message: "TypeError: Property 'temperature' does not exist on type 'ParameterTest'.",
+      message: "TypeError: TS2339 Property 'temperature' does not exist on type 'ParameterTest'.",
       stack: 'at BakeBananaBreadExpansionLogic(7:40)',
       sourceContext: ' 7|   return [\n' +
         '>8|     PREHEAT_OVEN(props.activityInstance.temperature),\n' +
@@ -318,7 +318,7 @@ test('Aerie undefined node test', async () => {
       location: { line: 7, column: 40 }
     }),
     expect.objectContaining({
-      message: "TypeError: Property 'tbSugar' does not exist on type 'ParameterTest'.",
+      message: "TypeError: TS2339 Property 'tbSugar' does not exist on type 'ParameterTest'.",
       stack: 'at BakeBananaBreadExpansionLogic(8:40)',
       sourceContext: ' 8|     PREHEAT_OVEN(props.activityInstance.temperature),\n' +
         '>9|     PREPARE_LOAF(props.activityInstance.tbSugar, props.activityInstance.glutenFree),\n' +
@@ -327,7 +327,7 @@ test('Aerie undefined node test', async () => {
       location: { line: 8, column: 40 }
     }),
     expect.objectContaining({
-      message: "TypeError: Property 'glutenFree' does not exist on type 'ParameterTest'.",
+      message: "TypeError: TS2339 Property 'glutenFree' does not exist on type 'ParameterTest'.",
       stack: 'at BakeBananaBreadExpansionLogic(8:72)',
       sourceContext: ' 8|     PREHEAT_OVEN(props.activityInstance.temperature),\n' +
         '>9|     PREPARE_LOAF(props.activityInstance.tbSugar, props.activityInstance.glutenFree),\n' +


### PR DESCRIPTION
## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? -->

Gives control over the type errors to isolate user messages from the runtime decisions (ie remove suggestions about how to change compiler options to resolve type errors)

A default mapper is supplied and will contain sensible defaults which can be added to as more cases are discovered.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? -->

Tests were updated

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and completeness? -->

No API changes

## Future work
<!-- What next steps can we anticipate from here, if any? -->

I definitely want to refactor all of the error messaging, but haven't spent enough time working with the ts diagnostics to know what the best approach is.