### PR TITLE
[FEAT] Import additional files as ambient

### DIFF
--- a/src/UserCodeRunner.ts
+++ b/src/UserCodeRunner.ts
@@ -89,7 +89,13 @@ export class UserCodeRunner {
 		);
 
 		const executionCode = `
-      import defaultExport from '${USER_FILE_ALIAS}';
+			${additionalSourceFiles.map(file => {
+				const extName = path.extname(file.fileName);
+				if (file.fileName.endsWith('.d.ts')) return '';
+				const fileNameSansExt = path.basename(file.fileName).replace(extName, '.js');
+				return `import '${fileNameSansExt}';`;
+			}).join('\n  ')}
+      import defaultExport from '${USER_FILE_ALIAS}.js';
       
       declare global {
         const args: [${argsTypes.join(', ')}];
@@ -231,8 +237,8 @@ export class UserCodeRunner {
 		}
 		const harnessModule = moduleCache.get(`${EXECUTION_HARNESS_FILENAME}.js`)!;
 		await harnessModule.link(specifier => {
-			if (moduleCache.has(specifier + '.js')) {
-				return moduleCache.get(specifier + '.js')!;
+			if (moduleCache.has(specifier)) {
+				return moduleCache.get(specifier)!;
 			}
 			throw new Error(`Unable to resolve dependency: ${specifier}`);
 		});

--- a/test/UserCodeRunner.spec.ts
+++ b/test/UserCodeRunner.spec.ts
@@ -184,7 +184,7 @@ it('should return the final value', async () => {
 
 it('should accept additional source files', async () => {
   const userCode = `
-    import { importedFunction } from 'other-importable';
+    import { importedFunction } from 'other-importable.js';
     export default function myDSLFunction(thing: string): string {
       return someGlobalFunction(thing) + importedFunction(' world');
     }
@@ -235,12 +235,8 @@ test('Aerie Throw Regression Test', async () => {
     fs.promises.readFile(new URL('./inputs/TemporalPolyfillTypes.ts', import.meta.url).pathname, 'utf8'),
   ]);
 
-  // @ts-ignore
-  const {Commands} = await import('./inputs/command-types.js');
-
   const context = vm.createContext({
     Temporal,
-    ...Commands,
   });
   const result = await runner.executeUserCode(
     userCode,

--- a/test/inputs/command-types.ts
+++ b/test/inputs/command-types.ts
@@ -166,3 +166,5 @@ export const Commands = {
 	PREPARE_LOAF: PREPARE_LOAF,
 	BAKE_BREAD: BAKE_BREAD,
 };
+
+Object.assign(globalThis, Commands);


### PR DESCRIPTION
To allow for patching the globalThis object, import any additional files at the beginning of the execution harness

For AERIE, this allows making the commands global from within the command-types.ts code.