### PR TITLE
[FIX] Error message mapper message

### DIFF
--- a/src/utils/errorMessageMapping.ts
+++ b/src/utils/errorMessageMapping.ts
@@ -1,11 +1,11 @@
 import type ts from "typescript";
 
 function callMapper(msg: string, code: number, errorCodeMessageMappers: {[errorCode: number]: (message: string) => string | undefined}): string {
-  const mesageMapper = errorCodeMessageMappers[code];
-  if (mesageMapper === undefined) {
+  const messageMapper = errorCodeMessageMappers[code];
+  if (messageMapper === undefined) {
     return msg;
   }
-  const mappedMessage = mesageMapper(msg);
+  const mappedMessage = messageMapper(msg);
   if (mappedMessage === undefined) {
     throw new Error(`Insufficient message mapper found for ts diagnostic code ${code}`);
   }
@@ -20,9 +20,12 @@ export function createMapDiagnosticMessage(errorCodeMessageMappers: {[errorCode:
         throw new Error('Must provide a code when mapping a string message');
       }
       errorMessages.push(callMapper(msg, code, errorCodeMessageMappers));
-    } else if (msg.next) {
-      for (const next of msg.next) {
-        errorMessages = errorMessages.concat(mapDiagnosticMessageChain(next, next.code));
+    } else {
+      errorMessages.push(callMapper(msg.messageText, msg.code, errorCodeMessageMappers));
+      if (msg.next) {
+        for (const next of msg.next) {
+          errorMessages = errorMessages.concat(mapDiagnosticMessageChain(next, next.code).map(m => `  ${m}`));
+        }
       }
     }
     return errorMessages;

--- a/test/inputs/dsl-model-specific--2345.ts
+++ b/test/inputs/dsl-model-specific--2345.ts
@@ -1,0 +1,25 @@
+/** Start Codegen */
+interface PeelBanana extends ActivityTemplate {}
+export const ActivityTemplates = {
+	PeelBanana: function PeelBanana(
+		args: {
+			duration: Duration,
+			fancy: { subfield1: string, subfield2: { subsubfield1: Double, }[], }
+			peelDirection: ("fromTip" | "fromStem")
+		}): PeelBanana {
+		return { activityType: 'PeelBanana', args };
+	},
+}
+declare global {
+	var ActivityTemplates: {
+		PeelBanana: (
+			args: {
+				duration: Duration,
+				fancy: { subfield1: string, subfield2: { subsubfield1: Double, }[], },
+				peelDirection: ("fromTip" | "fromStem")
+			}) => PeelBanana
+	}
+}
+// Make ActivityTemplates available on the global object
+Object.assign(globalThis, { ActivityTemplates });
+/** End Codegen */


### PR DESCRIPTION
The error message mapper was dropping the message text of DiagnosticMessageChain's