### PR TITLE
[FEAT] Handle return type error with no annotation

### DIFF
--- a/test/inputs/dsl-model-specific--2345.ts
+++ b/test/inputs/dsl-model-specific--2345.ts
@@ -1,4 +1,5 @@
 /** Start Codegen */
+import type { ActivityTemplate } from './scheduler-edsl-fluent-api.js';
 interface PeelBanana extends ActivityTemplate {}
 export const ActivityTemplates = {
 	PeelBanana: function PeelBanana(

--- a/test/inputs/dsl-model-specific.ts
+++ b/test/inputs/dsl-model-specific.ts
@@ -1,21 +1,26 @@
 /** Start Codegen */
+import type { ActivityTemplate } from './scheduler-edsl-fluent-api.js';
 interface PeelBanana extends ActivityTemplate {}
 export const ActivityTemplates = {
   PeelBanana: function PeelBanana(
     args: {
-      peelDirection: ("fromTip" | "fromStem")
+      duration: Duration,
+      fancy: { subfield1: string, subfield2: { subsubfield1: Double, }[], },
+      peelDirection: ('fromTip' | 'fromStem'),
     }): PeelBanana {
-      return { activityType: 'PeelBanana', args };
-    },
+    return { activityType: 'PeelBanana', args };
+  },
 }
 declare global {
   var ActivityTemplates: {
     PeelBanana: (
       args: {
-        peelDirection: ("fromTip" | "fromStem")
+        duration: Duration,
+        fancy: { subfield1: string, subfield2: { subsubfield1: Double, }[], },
+        peelDirection: ('fromTip' | 'fromStem'),
       }) => PeelBanana
   }
 }
-
+// Make ActivityTemplates available on the global object
 Object.assign(globalThis, { ActivityTemplates });
 /** End Codegen */

--- a/test/inputs/scheduler-ast.ts
+++ b/test/inputs/scheduler-ast.ts
@@ -1,24 +1,3 @@
-declare global {
-  type U<BitLength extends 8 | 16 | 32 | 64> = number;
-  type U8 = U<8>;
-  type U16 = U<16>;
-  type U32 = U<32>;
-  type U64 = U<64>;
-  type I<BitLength extends 8 | 16 | 32 | 64> = number;
-  type I8 = I<8>;
-  type I16 = I<16>;
-  type I32 = I<32>;
-  type I64 = string;
-  type VarString<PrefixBitLength extends number, MaxBitLength extends number> = string;
-  type F<BitLength extends 32 | 64> = number;
-  type F32 = F<32>;
-  type F64 = F<64>;
-  type Duration = F64;
-  type Integer = I32;
-  type Double = F64;
-  type Time = string;
-}
-
 export interface ActivityTemplate {
   activityType: string,
   args: {[key: string]: any},
@@ -40,7 +19,7 @@ export type Goal =
 export interface ActivityRecurrenceGoal {
   kind: 'ActivityRecurrenceGoal',
   activityTemplate: ActivityTemplate,
-  interval: Integer,
+  interval: number,
 }
 
 export type GoalSpecifier =

--- a/test/inputs/scheduler-edsl-fluent-api.ts
+++ b/test/inputs/scheduler-edsl-fluent-api.ts
@@ -1,8 +1,5 @@
 import type * as AST from './scheduler-ast.js';
 
-// For accessing the private field of WindowSet from Goal
-const GET_INTERNAL_SYMBOL = Symbol('GET_INTERNAL_SYMBOL');
-
 interface ActivityRecurrenceGoal extends Goal {}
 export class Goal {
   private readonly goalSpecifier: AST.GoalSpecifier;
@@ -15,7 +12,7 @@ export class Goal {
     return new Goal(goalSpecifier);
   }
 
-  public get [GET_INTERNAL_SYMBOL](): AST.GoalSpecifier {
+  private __serialize(): AST.GoalSpecifier {
     return this.goalSpecifier;
   }
 
@@ -39,7 +36,7 @@ export class Goal {
     });
   }
 
-  public static ActivityRecurrenceGoal(opts: { activityTemplate: ActivityTemplate, interval: Integer }): ActivityRecurrenceGoal {
+  public static ActivityRecurrenceGoal(opts: { activityTemplate: ActivityTemplate, interval: Duration }): ActivityRecurrenceGoal {
     return Goal.new({
       kind: 'ActivityRecurrenceGoal',
       activityTemplate: opts.activityTemplate,
@@ -54,15 +51,14 @@ declare global {
 
     public or(...others: Goal[]): Goal
 
-    public static ActivityRecurrenceGoal(opts: { activityTemplate: ActivityTemplate, interval: Integer }): ActivityRecurrenceGoal
+    public static ActivityRecurrenceGoal(opts: { activityTemplate: ActivityTemplate, interval: Duration }): ActivityRecurrenceGoal
   }
-  interface ActivityTemplate extends AST.ActivityTemplate {}
+  type Duration = number;
+  type Double = number;
+  type Integer = number;
 }
 
+export interface ActivityTemplate extends AST.ActivityTemplate {}
 
-
-export function serializeGoal(goal: Goal): AST.GoalSpecifier {
-  return goal[GET_INTERNAL_SYMBOL];
-}
-
-(globalThis as any).Goal = Goal;
+// Make Goal available on the global object
+Object.assign(globalThis, { Goal });


### PR DESCRIPTION
Because we are pulling the return type from the function signature for the message, when there is no return type, we need to get it another way and report the diagnostic on the actual return node rather than the signature