### PR TITLE
[BUGFIX] Remove extension for module cache keys

### DIFF
--- a/src/UserCodeRunner.ts
+++ b/src/UserCodeRunner.ts
@@ -220,8 +220,9 @@ export class UserCodeRunner {
 		}
 		const harnessModule = moduleCache.get(EXECUTION_HARNESS_FILENAME)!;
 		await harnessModule.link(specifier => {
-			if (moduleCache.has(specifier)) {
-				return moduleCache.get(specifier)!;
+			const filenameSansExt = removeExt(specifier);
+			if (moduleCache.has(filenameSansExt)) {
+				return moduleCache.get(filenameSansExt)!;
 			}
 			throw new Error(`Unable to resolve dependency: ${specifier}`);
 		});

--- a/src/UserCodeRunner.ts
+++ b/src/UserCodeRunner.ts
@@ -58,8 +58,8 @@ export class UserCodeRunner {
 		const executionCode = `
 			${additionalSourceFiles.map(file => {
 				if (file.fileName.endsWith('.d.ts')) return '';
-				const fileNameSansExt = removeExt(file.fileName);
-				return `import '${fileNameSansExt}';`;
+				const filenameSansExt = removeExt(file.fileName);
+				return `import '${filenameSansExt}';`;
 			}).join('\n  ')}
       import defaultExport from '${USER_CODE_FILENAME}';
             

--- a/test/inputs/scheduler-ast.ts
+++ b/test/inputs/scheduler-ast.ts
@@ -3,6 +3,8 @@ export interface ActivityTemplate {
   args: {[key: string]: any},
 }
 
+export const dummyValue = "some value" // used to test importing values from this file
+
 /**
  * Goal
  *

--- a/test/inputs/scheduler-edsl-fluent-api.ts
+++ b/test/inputs/scheduler-edsl-fluent-api.ts
@@ -1,4 +1,6 @@
-import type * as AST from './scheduler-ast.js';
+import * as AST from './scheduler-ast.js';
+
+const myDummyValue = AST.dummyValue;
 
 interface ActivityRecurrenceGoal extends Goal {}
 export class Goal {


### PR DESCRIPTION
### Description

Typical imports look like `import './file.js'`, whereas our cache keys have stripped the extension and path prefix already. This was resulting in errors with the message, `Unable to resolve dependency './scheduler-ast.js'`.

 ### Verification
We updated the tests to actually import a value from another file, and observed that they failed. After making this change, all tests passed.
