### PR TITLE
Help VM to Clear Memory 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nasa-jpl/aerie-ts-user-code-runner",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nasa-jpl/aerie-ts-user-code-runner",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "source-map": "^0.7.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nasa-jpl/aerie-ts-user-code-runner",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "A simple way to safely run user code written in Typescript.",
   "main": "build/UserCodeRunner.js",
   "type": "module",

--- a/src/UserCodeRunner.ts
+++ b/src/UserCodeRunner.ts
@@ -239,7 +239,10 @@ export class UserCodeRunner {
 			await harnessModule.evaluate({
 				timeout,
 			});
-			return Result.Ok(context.__result);
+			const result = context.__result;
+			delete context.__args;
+			delete context.__result;
+			return Result.Ok(result);
 		} catch (error: any) {
 			return Result.Err([UserCodeRuntimeError.new(error as Error, await new SourceMapConsumer(sourceMap))]);
 		}


### PR DESCRIPTION
During our investigation of a memory leak. We are noticing an increase in the heap size that never gets cleaned up by the garbage collector. This change will clear out the vm.context object which helps the heap size significantly.

Reviewed in a slack huddle with @dandelany and @JoelCourtney  